### PR TITLE
change image links from public to local

### DIFF
--- a/nodes/http-auth.html
+++ b/nodes/http-auth.html
@@ -67,11 +67,11 @@
 
 <p>This Node-RED module performs Basic and Digest authentication.<br />It is to be used in conjunction with an http input node.</p>
 
-<img src="https://raw.githubusercontent.com/endemecio02/node-red-contrib-httpauth/master/images/flow.png" />
+<img src="/node-red-contrib-httpauth/images/flow.png" />
 
 <h2>Config</h2>
 
-<img src="https://raw.githubusercontent.com/endemecio02/node-red-contrib-httpauth/master/images/config.png" />
+<img src="/node-red-contrib-httpauth/images/config.png" />
 
 <p>There are three type of configuration:</p>
 <ol>
@@ -103,9 +103,9 @@
 </ul>
 <h3>File Configuration</h3>
 
-<img src="https://raw.githubusercontent.com/endemecio02/node-red-contrib-httpauth/master/images/file.png" />
+<img src="/node-red-contrib-httpauth/images/file.png" />
 
 <h3>Shared config</h3>
 
-<img src="https://raw.githubusercontent.com/endemecio02/node-red-contrib-httpauth/master/images/cred.png" />
+<img src="/node-red-contrib-httpauth/images/cred.png" />
 </script>

--- a/nodes/http-auth.js
+++ b/nodes/http-auth.js
@@ -209,4 +209,12 @@ module.exports = function(RED) {
 	}
 
 	RED.nodes.registerType("node-red-contrib-httpauth", HttpAuthNode);
+	
+	var fs = require("fs");
+	RED.httpAdmin.get("/node-red-contrib-httpauth/images/:file", function(req, res, next){
+		fs.readFile(__dirname + '/../images/' + req.params.file, function(err, data){
+			res.set('Content-Type', 'image/png');
+			res.send(data);
+		});
+	});
 };


### PR DESCRIPTION
Hi, Thank you for your great work.
I want to avoid getting image files from a public site.
`<img src="https://raw.githubusercontent.com/...." />`


So I patch this. 
Currently I can get those image files from local Node-RED admin server(httpAdmin ).
`<img src="/node-red-contrib-httpauth/..." />`

